### PR TITLE
Force FRCBuild to execute a full build

### DIFF
--- a/.github/workflows/frcbuild.yml
+++ b/.github/workflows/frcbuild.yml
@@ -1,5 +1,5 @@
 name: FRC Build & Test
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -9,4 +9,4 @@ jobs:
     - name: FRC Build & Test
       uses: ewpratten/FRC-actions@v1.1.1
       with:
-        build_mode: 'build'
+        build_mode: 'all'


### PR DESCRIPTION
As far as I can tell, the cause of the false-negative builds from frcbuild is the fact that the `build` flag only assembles sources, without doing a full build or check. I changed this, and now the build appears to be working (failing correctly). 

[Build Log](https://pipelines.actions.githubusercontent.com/LD1vuPeeuizswBoHmg4wGWZZeEFC0qHx5WDAioVs4arUZRddSO/_apis/pipelines/1/runs/2/signedlogcontent/3?urlExpires=2020-02-19T02%3A12%3A29.5575400Z&urlSigningMethod=HMACV1&urlSignature=WF%2BveQhmERJpCUfty%2Bv3YN3GQuAdKaa4wj7humqEhbg%3D)

Related GitHub issue: https://github.com/Ewpratten/FRC-actions/issues/3